### PR TITLE
Use default location of fdb.cluster.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,8 @@
-mv /etc/foundationdb/fdb.cluster /fdb/fdb.cluster
 IP=$(getent hosts $(hostname) | cut -d ' ' -f1)
 sed -i \
     -e "s/\(public_address = \).*/\1$IP:\$ID/" \
     -e 's/\(listen_address = \).*/\10.0.0.0:$ID/' \
-    -e 's/\(cluster_file = \).*/\1\/fdb\/fdb.cluster/' \
     /etc/foundationdb/foundationdb.conf
 
-(sleep 1 && fdbcli -C /fdb/fdb.cluster --exec "coordinators $IP:4500" &)
+(sleep 1 && fdbcli --exec "coordinators $IP:4500" &)
 exec /usr/lib/foundationdb/fdbmonitor


### PR DESCRIPTION
I pushed an image as `hiroshi3110/foundationdb:5.1.5-1_ubuntu-16.04-gke`.

It works with following statefulset in a GKE 1.9.7 cluster.
```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: foundationdb
spec:
  # NOTE: Label selector that determines which Pods belong to the StatefulSet                                            
  selector:
    matchLabels:
      app: foundationdb # has to match .spec.template.metadata.labels                                                    
  serviceName: foundationdb
  replicas: 1
  template:
    metadata:
      labels:
        app: foundationdb # has to match .spec.selector.matchLabels                                                      
    spec:
      # terminationGracePeriodSeconds: 10                                                                                
      containers:
      - name: foundationdb
        image: hiroshi3110/foundationdb:5.1.5-1_ubuntu-16.04-gke
        command: ["/root/tini"]
        args: ["--", "sh", "/root/start.sh"]
        ports:
        - containerPort: 4500
          name: fdb
```

However, I wonder how to share the `fdb.cluster` file with clients in other pods possibly in a different node.